### PR TITLE
Fix deleted session test

### DIFF
--- a/tests/deleted_session.hurl
+++ b/tests/deleted_session.hurl
@@ -3,6 +3,7 @@
 # Ensure the session is gone (idempotent)
 DELETE http://localhost:8080/{{uuid}}
 
+HTTP/1.1 204
 
 # GET after delete
 GET http://localhost:8080/{{uuid}}


### PR DESCRIPTION
## Summary
- expect HTTP 204 status after deleting a session in tests/deleted_session.hurl

## Testing
- `go fmt ./...` *(fails: no route to host)*
- `go vet ./...` *(fails: no route to host)*